### PR TITLE
feat: Improve Social Service Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@dcl/crypto": "^3.4.5",
         "@dcl/eslint-config": "^1.1.8",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-14523877809.commit-39c10e9.tgz",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15850084249.commit-ce7a4eb.tgz",
         "@types/jest": "^29.5.3",
         "@types/ws": "^8.5.5",
         "eslint-plugin-prettier": "^5.0.0",
@@ -722,12 +722,13 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-14523877809.commit-39c10e9",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-14523877809.commit-39c10e9.tgz",
-      "integrity": "sha512-uO5OOwgKf9narXSuum/IlNYp2Q4mNhVInULPQdXYwvHwspXWihBOuQlAPHwLanOVs4EGkN5TSdiR2F2Z99fygg==",
+      "version": "1.0.0-15850084249.commit-ce7a4eb",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15850084249.commit-ce7a4eb.tgz",
+      "integrity": "sha512-8wCPaJljbsRB5kvCkCXGfne6jkUFD8xulgt+3sNY/MYZVq/vt3JWAPEqGENoR+rfJryCajrmDBmnhUMTY12U9w==",
       "dev": true,
       "dependencies": {
-        "@dcl/ts-proto": "1.154.0"
+        "@dcl/ts-proto": "1.154.0",
+        "protobufjs": "7.2.4"
       }
     },
     "node_modules/@dcl/rpc": {
@@ -7178,11 +7179,12 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-14523877809.commit-39c10e9.tgz",
-      "integrity": "sha512-uO5OOwgKf9narXSuum/IlNYp2Q4mNhVInULPQdXYwvHwspXWihBOuQlAPHwLanOVs4EGkN5TSdiR2F2Z99fygg==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15850084249.commit-ce7a4eb.tgz",
+      "integrity": "sha512-8wCPaJljbsRB5kvCkCXGfne6jkUFD8xulgt+3sNY/MYZVq/vt3JWAPEqGENoR+rfJryCajrmDBmnhUMTY12U9w==",
       "dev": true,
       "requires": {
-        "@dcl/ts-proto": "1.154.0"
+        "@dcl/ts-proto": "1.154.0",
+        "protobufjs": "7.2.4"
       }
     },
     "@dcl/rpc": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@dcl/crypto": "^3.4.5",
     "@dcl/eslint-config": "^1.1.8",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-14523877809.commit-39c10e9.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15850084249.commit-ce7a4eb.tgz",
     "@types/jest": "^29.5.3",
     "@types/ws": "^8.5.5",
     "eslint-plugin-prettier": "^5.0.0",

--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -1,11 +1,16 @@
+import { RpcClientPort } from '@dcl/rpc'
 import { createRpcClient } from '@dcl/rpc/dist/client'
 import { loadService } from '@dcl/rpc/dist/codegen'
 import { RawClient, FromTsProtoServiceDefinition } from '@dcl/rpc/dist/codegen-types'
 import { AuthIdentity, signedHeaderFactory } from 'decentraland-crypto-fetch'
-import { processErrors } from './errors'
+import { hasOkResponse, processErrors, SocialClientIncompleteResponseError } from './errors'
 import {
+  AcceptPrivateVoiceChatPayload,
+  AcceptPrivateVoiceChatResponse,
   BlockUserPayload,
   BlockUserResponse,
+  EndPrivateVoiceChatPayload,
+  EndPrivateVoiceChatResponse,
   FriendConnectivityUpdate,
   GetBlockedUsersPayload,
   GetBlockedUsersResponse,
@@ -18,11 +23,16 @@ import {
   GetPrivateMessagesSettingsPayload,
   GetPrivateMessagesSettingsResponse,
   GetSocialSettingsResponse,
+  GetIncomingPrivateVoiceChatRequestResponse,
   PaginatedFriendshipRequestsResponse,
   PaginatedFriendsProfilesResponse,
   Pagination,
+  RejectPrivateVoiceChatPayload,
+  RejectPrivateVoiceChatResponse,
   SocialServiceDefinition,
   SocialSettings,
+  StartPrivateVoiceChatPayload,
+  StartPrivateVoiceChatResponse,
   UnblockUserPayload,
   UnblockUserResponse,
   UpsertFriendshipPayload,
@@ -39,6 +49,7 @@ const signHeader = signedHeaderFactory()
 export async function createSocialClientV2(socialClientRpcUrl: string, identity: AuthIdentity) {
   let service: RawClient<FromTsProtoServiceDefinition<SocialServiceDefinition>>
   const webSocketsTransport = createWebSocketsTransport(socialClientRpcUrl)
+  let port: RpcClientPort
   return {
     connect: async () => {
       // Create the authorization headers
@@ -61,7 +72,7 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
 
       webSocketsTransport.connect()
       const rpcClient = await createRpcClient(webSocketsTransport)
-      const port = await rpcClient.createPort('social')
+      port = await rpcClient.createPort('social')
       await promiseOfAuthorization
       service = loadService(port, SocialServiceDefinition)
     },
@@ -76,6 +87,9 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
       })
     },
     disconnect: () => {
+      if (port) {
+        port.close()
+      }
       webSocketsTransport.close()
     },
     onTransportError: (error: Error) => {
@@ -94,74 +108,74 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
       return response
     },
     // TODO: Make it return the status as non undefined
-    getFriendshipStatus: async function (address: string): Promise<Required<GetFriendshipStatusResponse['accepted']>> {
+    getFriendshipStatus: async function (address: string): Promise<NonNullable<GetFriendshipStatusResponse['accepted']>> {
       const response = await service.getFriendshipStatus(GetFriendshipStatusPayload.create({ user: User.create({ address }) }))
       processErrors(response)
 
       if (!response.accepted) {
-        throw new Error('Friendship status has an incomplete response')
+        throw new SocialClientIncompleteResponseError()
       }
 
-      return response.accepted as Required<GetFriendshipStatusResponse['accepted']>
+      return response.accepted
     },
     getMutualFriends: async function (address: string): Promise<PaginatedFriendsProfilesResponse> {
       // TODO: The protocol should return errors in case of failure
       return service.getMutualFriends(GetMutualFriendsPayload.create({ user: User.create({ address }) }))
     },
     // TODO: Make it return the status as non undefined
-    requestFriendship: async function (address: string, message?: string): Promise<Required<UpsertFriendshipResponse['accepted']>> {
+    requestFriendship: async function (address: string, message?: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
       const response = await service.upsertFriendship(
         UpsertFriendshipPayload.create({ request: { user: User.create({ address }), message } })
       )
       processErrors(response)
 
       if (!response.accepted) {
-        throw new Error('Friendship request has an incomplete response')
+        throw new SocialClientIncompleteResponseError()
       }
 
-      return response.accepted as Required<UpsertFriendshipResponse['accepted']>
+      return response.accepted
     },
     // TODO: Make it return the status as non undefined
-    acceptFriendshipRequest: async function (address: string): Promise<Required<UpsertFriendshipResponse['accepted']>> {
+    acceptFriendshipRequest: async function (address: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
       const response = await service.upsertFriendship(UpsertFriendshipPayload.create({ accept: { user: User.create({ address }) } }))
       processErrors(response)
 
       if (!response.accepted) {
-        throw new Error('Friendship request has an incomplete response')
+        throw new SocialClientIncompleteResponseError()
       }
 
-      return response.accepted as Required<UpsertFriendshipResponse['accepted']>
+      return response.accepted
     },
     // TODO: Make it return the status as non undefined
-    rejectFriendshipRequest: async function (address: string): Promise<Required<UpsertFriendshipResponse['accepted']>> {
+    rejectFriendshipRequest: async function (address: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
       const response = await service.upsertFriendship(UpsertFriendshipPayload.create({ reject: { user: User.create({ address }) } }))
       processErrors(response)
 
       if (!response.accepted) {
-        throw new Error('Friendship request has an incomplete response')
+        throw new SocialClientIncompleteResponseError()
       }
 
-      return response.accepted as Required<UpsertFriendshipResponse['accepted']>
+      return response.accepted
     },
-    deleteFriendshipRequest: async function (address: string): Promise<Required<UpsertFriendshipResponse['accepted']>> {
+    deleteFriendshipRequest: async function (address: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
       const response = await service.upsertFriendship(UpsertFriendshipPayload.create({ delete: { user: User.create({ address }) } }))
       processErrors(response)
 
       if (!response.accepted) {
-        throw new Error('Friendship request has an incomplete response')
+        throw new SocialClientIncompleteResponseError()
       }
 
-      return response.accepted as Required<UpsertFriendshipResponse['accepted']>
+      return response.accepted
     },
-    cancelFriendshipRequest: async function (address: string): Promise<Required<UpsertFriendshipResponse['accepted']>> {
+    cancelFriendshipRequest: async function (address: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
       const response = await service.upsertFriendship(UpsertFriendshipPayload.create({ cancel: { user: User.create({ address }) } }))
       processErrors(response)
 
       if (!response.accepted) {
-        throw new Error('Friendship request has an incomplete response')
+        throw new SocialClientIncompleteResponseError()
       }
 
-      return response.accepted as Required<UpsertFriendshipResponse['accepted']>
+      return response.accepted
     },
     subscribeToFriendConnectivityUpdates: async function* (): AsyncGenerator<FriendConnectivityUpdate, void, unknown> {
       const response = service.subscribeToFriendConnectivityUpdates(Empty.create())
@@ -177,22 +191,31 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
         yield friendshipUpdate
       }
     },
-    getSocialSettings: async function (): Promise<GetSocialSettingsResponse> {
+    getSocialSettings: async function (): Promise<NonNullable<GetSocialSettingsResponse['ok']>> {
       const response = await service.getSocialSettings(Empty.create())
       processErrors(response)
-      return response
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
     },
-    upsertSocialSettings: async function (settings: Partial<SocialSettings>): Promise<UpsertSocialSettingsResponse> {
+    upsertSocialSettings: async function (settings: Partial<SocialSettings>): Promise<NonNullable<UpsertSocialSettingsResponse['ok']>> {
       const response = await service.upsertSocialSettings(UpsertSocialSettingsPayload.create(settings))
       processErrors(response)
-      return response
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
     },
-    getPrivateMessagesSettings: async function (addresses: string[]): Promise<GetPrivateMessagesSettingsResponse> {
+    getPrivateMessagesSettings: async function (addresses: string[]): Promise<NonNullable<GetPrivateMessagesSettingsResponse['ok']>> {
       const response = await service.getPrivateMessagesSettings(
         GetPrivateMessagesSettingsPayload.create({ user: addresses.map(address => User.create({ address })) })
       )
       processErrors(response)
-      return response
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
     },
     subscribeToBlockUpdates: async function* () {
       const response = service.subscribeToBlockUpdates(Empty.create())
@@ -207,11 +230,68 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
     getBlockedUsers: async function (pagination?: Pagination): Promise<GetBlockedUsersResponse> {
       return service.getBlockedUsers(GetBlockedUsersPayload.create({ pagination }))
     },
-    unblockUser: async function (address: string): Promise<UnblockUserResponse> {
-      return service.unblockUser(UnblockUserPayload.create({ user: User.create({ address }) }))
+    unblockUser: async function (address: string): Promise<NonNullable<UnblockUserResponse['ok']>> {
+      const response = await service.unblockUser(UnblockUserPayload.create({ user: User.create({ address }) }))
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
     },
-    blockUser: async function (address: string): Promise<BlockUserResponse> {
-      return service.blockUser(BlockUserPayload.create({ user: User.create({ address }) }))
+    blockUser: async function (address: string): Promise<NonNullable<BlockUserResponse['ok']>> {
+      const response = await service.blockUser(BlockUserPayload.create({ user: User.create({ address }) }))
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
+    },
+    startPrivateVoiceChat: async function (address: string): Promise<NonNullable<StartPrivateVoiceChatResponse['ok']>> {
+      const response = await service.startPrivateVoiceChat(StartPrivateVoiceChatPayload.create({ callee: User.create({ address }) }))
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
+    },
+    rejectPrivateVoiceChat: async function (callId: string): Promise<NonNullable<RejectPrivateVoiceChatResponse['ok']>> {
+      const response = await service.rejectPrivateVoiceChat(RejectPrivateVoiceChatPayload.create({ callId }))
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
+    },
+    acceptPrivateVoiceChat: async function (callId: string): Promise<NonNullable<AcceptPrivateVoiceChatResponse['ok']>> {
+      const response = await service.acceptPrivateVoiceChat(AcceptPrivateVoiceChatPayload.create({ callId }))
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
+    },
+    subscribeToPrivateVoiceChatUpdates: async function* () {
+      const response = service.subscribeToPrivateVoiceChatUpdates(Empty.create())
+      for await (const privateVoiceChatUpdate of response) {
+        // TODO: The protocol should return errors in case of failure
+        yield privateVoiceChatUpdate
+      }
+    },
+    endPrivateVoiceChat: async function (callId: string): Promise<NonNullable<EndPrivateVoiceChatResponse['ok']>> {
+      const response = await service.endPrivateVoiceChat(EndPrivateVoiceChatPayload.create({ callId }))
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
+    },
+    getIncomingPrivateVoiceChatRequests: async function (): Promise<NonNullable<GetIncomingPrivateVoiceChatRequestResponse['ok']>> {
+      const response = await service.getIncomingPrivateVoiceChatRequest(Empty.create())
+      processErrors(response)
+      if (!hasOkResponse(response)) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return response.ok
     }
   }
 }

--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -46,7 +46,7 @@ import { createWebSocketsTransport } from './transport'
 
 const signHeader = signedHeaderFactory()
 
-export async function createSocialClientV2(socialClientRpcUrl: string) {
+export function createSocialClientV2(socialClientRpcUrl: string) {
   let service: RawClient<FromTsProtoServiceDefinition<SocialServiceDefinition>>
   const webSocketsTransport = createWebSocketsTransport(socialClientRpcUrl)
   let port: RpcClientPort

--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -46,12 +46,12 @@ import { createWebSocketsTransport } from './transport'
 
 const signHeader = signedHeaderFactory()
 
-export async function createSocialClientV2(socialClientRpcUrl: string, identity: AuthIdentity) {
+export async function createSocialClientV2(socialClientRpcUrl: string) {
   let service: RawClient<FromTsProtoServiceDefinition<SocialServiceDefinition>>
   const webSocketsTransport = createWebSocketsTransport(socialClientRpcUrl)
   let port: RpcClientPort
   return {
-    connect: async () => {
+    connect: async (identity: AuthIdentity) => {
       // Create the authorization headers
       const signedHeaders = signHeader(identity, 'GET', '/', {})
       const signedHeadersEntries: Record<string, string> = {}

--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -99,13 +99,45 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
       // TODO: The protocol should return errors in case of failure
       return service.getFriends(GetFriendsPayload.create({ pagination }))
     },
-    getPendingFriendshipRequests: async function (pagination?: Pagination): Promise<PaginatedFriendshipRequestsResponse> {
-      return service.getPendingFriendshipRequests(GetFriendshipRequestsPayload.create({ pagination }))
+    getPendingFriendshipRequests: async function (
+      pagination?: Pagination
+    ): Promise<
+      Required<
+        { requests: NonNullable<PaginatedFriendshipRequestsResponse['requests']>['requests'] } & Pick<
+          PaginatedFriendshipRequestsResponse,
+          'paginationData'
+        >
+      >
+    > {
+      const response = await service.getPendingFriendshipRequests(GetFriendshipRequestsPayload.create({ pagination }))
+      processErrors(response)
+      if (!response.requests?.requests || !response.paginationData) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return {
+        requests: response.requests.requests,
+        paginationData: response.paginationData
+      }
     },
-    getSentFriendshipRequests: async function (pagination?: Pagination): Promise<PaginatedFriendshipRequestsResponse> {
+    getSentFriendshipRequests: async function (
+      pagination?: Pagination
+    ): Promise<
+      Required<
+        { requests: NonNullable<PaginatedFriendshipRequestsResponse['requests']>['requests'] } & Pick<
+          PaginatedFriendshipRequestsResponse,
+          'paginationData'
+        >
+      >
+    > {
       const response = await service.getSentFriendshipRequests(GetFriendshipRequestsPayload.create({ pagination }))
       processErrors(response)
-      return response
+      if (!response.requests?.requests || !response.paginationData) {
+        throw new SocialClientIncompleteResponseError()
+      }
+      return {
+        requests: response.requests.requests,
+        paginationData: response.paginationData
+      }
     },
     // TODO: Make it return the status as non undefined
     getFriendshipStatus: async function (address: string): Promise<NonNullable<GetFriendshipStatusResponse['accepted']>> {
@@ -118,9 +150,9 @@ export async function createSocialClientV2(socialClientRpcUrl: string, identity:
 
       return response.accepted
     },
-    getMutualFriends: async function (address: string): Promise<PaginatedFriendsProfilesResponse> {
+    getMutualFriends: async function (address: string, pagination?: Pagination): Promise<PaginatedFriendsProfilesResponse> {
       // TODO: The protocol should return errors in case of failure
-      return service.getMutualFriends(GetMutualFriendsPayload.create({ user: User.create({ address }) }))
+      return service.getMutualFriends(GetMutualFriendsPayload.create({ user: User.create({ address }), pagination }))
     },
     // TODO: Make it return the status as non undefined
     requestFriendship: async function (address: string, message?: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {

--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -189,7 +189,7 @@ export function createSocialClientV2(socialClientRpcUrl: string) {
 
       return response.accepted
     },
-    deleteFriendshipRequest: async function (address: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
+    removeFriendship: async function (address: string): Promise<NonNullable<UpsertFriendshipResponse['accepted']>> {
       const response = await service.upsertFriendship(UpsertFriendshipPayload.create({ delete: { user: User.create({ address }) } }))
       processErrors(response)
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,6 +8,7 @@ import {
 import {
   InternalServerError as InternalServerErrorV2,
   InvalidFriendshipAction,
+  ForbiddenError as ForbiddenErrorV2,
   InvalidRequest as InvalidRequestV2
 } from './protobuff-types/decentraland/social_service/v2/social_service_v2.gen'
 
@@ -47,10 +48,16 @@ export class SynapseLoginError extends Error {
   }
 }
 
+export class SocialClientIncompleteResponseError extends Error {
+  constructor() {
+    super('The response is incomplete')
+  }
+}
+
 type Errors = {
   internalServerError?: InternalServerError | InternalServerErrorV2 | undefined
   unauthorizedError?: UnauthorizedError | undefined
-  forbiddenError?: ForbiddenError | undefined
+  forbiddenError?: ForbiddenError | ForbiddenErrorV2 | undefined
   tooManyRequestsError?: TooManyRequestsError | undefined
   badRequestError?: BadRequestError | InvalidRequestV2 | InvalidFriendshipAction | undefined
 }
@@ -59,7 +66,7 @@ export function processErrors(response: Errors): void {
   if (response.badRequestError) {
     throw new SocialClientBadRequestError(response.badRequestError.message ?? 'Unknown error')
   } else if (response.forbiddenError) {
-    throw new SocialClientForbiddenError(response.forbiddenError.message)
+    throw new SocialClientForbiddenError(response.forbiddenError.message ?? 'Unknown error')
   } else if (response.internalServerError) {
     throw new SocialClientInternalServerError(response.internalServerError.message ?? 'Unknown error')
   } else if (response.tooManyRequestsError) {
@@ -67,6 +74,10 @@ export function processErrors(response: Errors): void {
   } else if (response.unauthorizedError) {
     throw new SocialClientUnauthorizedError(response.unauthorizedError.message)
   }
+}
+
+export function hasOkResponse<T extends { ok?: unknown }>(response: T): response is T & { ok: NonNullable<T['ok']> } {
+  return response.ok !== undefined && response.ok !== null
 }
 
 export function isErrorWithMessage(error: unknown): error is Error {

--- a/tests/client-v2.spec.ts
+++ b/tests/client-v2.spec.ts
@@ -562,13 +562,13 @@ describe('when creating a new client v2', () => {
       })
 
       it('should reject with the error', () => {
-        return expect(result.deleteFriendshipRequest(targetAddress)).rejects.toThrow(
+        return expect(result.removeFriendship(targetAddress)).rejects.toThrow(
           new SocialClientInternalServerError(response.internalServerError?.message ?? '')
         )
       })
 
       it('should reject with the specific error', () => {
-        return expect(result.deleteFriendshipRequest(targetAddress)).rejects.toThrow(SocialClientInternalServerError)
+        return expect(result.removeFriendship(targetAddress)).rejects.toThrow(SocialClientInternalServerError)
       })
     })
 
@@ -591,7 +591,7 @@ describe('when creating a new client v2', () => {
       })
 
       it('should return the friendship status', async () => {
-        await expect(result.deleteFriendshipRequest(targetAddress)).resolves.toEqual(response.accepted)
+        await expect(result.removeFriendship(targetAddress)).resolves.toEqual(response.accepted)
         expect(loadServiceResult.upsertFriendship).toHaveBeenCalledWith(
           UpsertFriendshipPayload.create({ delete: { user: User.create({ address: targetAddress }) } })
         )

--- a/tests/client-v2.spec.ts
+++ b/tests/client-v2.spec.ts
@@ -58,7 +58,7 @@ describe('when creating a new client v2', () => {
   let port: RpcClientPort
   let portCloseMock: jest.MockedFunction<RpcClientPort['close']>
   let loadServiceResult: jest.Mocked<ReturnType<typeof loadService<object, SocialServiceDefinition>>>
-  let result: Awaited<ReturnType<typeof createSocialClientV2>>
+  let result: ReturnType<typeof createSocialClientV2>
   let targetAddress: string
 
   beforeEach(async () => {
@@ -131,7 +131,7 @@ describe('when creating a new client v2', () => {
     })
 
     // Create the client
-    result = await createSocialClientV2(socialClientRpcUrl)
+    result = createSocialClientV2(socialClientRpcUrl)
     await result.connect(identity)
   })
 

--- a/tests/client-v2.spec.ts
+++ b/tests/client-v2.spec.ts
@@ -218,7 +218,10 @@ describe('when creating a new client v2', () => {
       })
 
       it('should return the pending requests', async () => {
-        await expect(result.getPendingFriendshipRequests()).resolves.toEqual(response)
+        await expect(result.getPendingFriendshipRequests()).resolves.toEqual({
+          requests: response.requests?.requests,
+          paginationData: response.paginationData
+        })
         expect(loadServiceResult.getPendingFriendshipRequests).toHaveBeenCalledWith(
           GetFriendshipRequestsPayload.create({ pagination: undefined })
         )
@@ -272,7 +275,10 @@ describe('when creating a new client v2', () => {
       })
 
       it('should return the sent requests', async () => {
-        await expect(result.getSentFriendshipRequests()).resolves.toEqual(response)
+        await expect(result.getSentFriendshipRequests()).resolves.toEqual({
+          requests: response.requests?.requests,
+          paginationData: response.paginationData
+        })
         expect(loadServiceResult.getSentFriendshipRequests).toHaveBeenCalledWith(
           GetFriendshipRequestsPayload.create({ pagination: undefined })
         )

--- a/tests/client-v2.spec.ts
+++ b/tests/client-v2.spec.ts
@@ -131,8 +131,8 @@ describe('when creating a new client v2', () => {
     })
 
     // Create the client
-    result = await createSocialClientV2(socialClientRpcUrl, identity)
-    await result.connect()
+    result = await createSocialClientV2(socialClientRpcUrl)
+    await result.connect(identity)
   })
 
   it('should connect to the Social RPC server', () => {

--- a/tests/client-v2.spec.ts
+++ b/tests/client-v2.spec.ts
@@ -7,8 +7,12 @@ import { AuthIdentity } from 'decentraland-crypto-fetch'
 import { createSocialClientV2 } from '../src/client-v2'
 import { SocialClientInternalServerError } from '../src/errors'
 import {
+  AcceptPrivateVoiceChatPayload,
+  AcceptPrivateVoiceChatResponse,
   BlockUserPayload,
   BlockUserResponse,
+  EndPrivateVoiceChatPayload,
+  EndPrivateVoiceChatResponse,
   GetBlockedUsersPayload,
   GetBlockedUsersResponse,
   GetBlockingStatusResponse,
@@ -16,13 +20,18 @@ import {
   GetFriendshipStatusPayload,
   GetFriendshipStatusResponse,
   GetFriendsPayload,
+  GetIncomingPrivateVoiceChatRequestResponse,
   GetMutualFriendsPayload,
   GetPrivateMessagesSettingsPayload,
   GetPrivateMessagesSettingsResponse,
   GetSocialSettingsResponse,
   PaginatedFriendshipRequestsResponse,
   PaginatedFriendsProfilesResponse,
+  RejectPrivateVoiceChatPayload,
+  RejectPrivateVoiceChatResponse,
   SocialServiceDefinition,
+  StartPrivateVoiceChatPayload,
+  StartPrivateVoiceChatResponse,
   UnblockUserPayload,
   UnblockUserResponse,
   UpsertFriendshipPayload,
@@ -38,51 +47,25 @@ jest.mock('../src/transport')
 jest.mock('@dcl/rpc/dist/codegen')
 jest.mock('@dcl/rpc/dist/client')
 
-const createRpcClientMock = jest.mocked(createRpcClient)
-const createWebSocketsTransportMock = jest.mocked(createWebSocketsTransport)
-const loadServiceMock = jest.mocked(loadService)
-
 describe('when creating a new client v2', () => {
+  let createRpcClientMock: jest.MockedFunction<typeof createRpcClient>
+  let createWebSocketsTransportMock: jest.MockedFunction<typeof createWebSocketsTransport>
+  let loadServiceMock: jest.MockedFunction<typeof loadService>
   let socialClientRpcUrl: string
   let identity: AuthIdentity
   let transport: Transport & { connect: () => void; sendMessage: jest.Mock; on: jest.Mock; close: jest.Mock }
   let rpcClient: RpcClient
   let port: RpcClientPort
-  let loadServiceResult: ReturnType<typeof loadService<object, SocialServiceDefinition>>
+  let portCloseMock: jest.MockedFunction<RpcClientPort['close']>
+  let loadServiceResult: jest.Mocked<ReturnType<typeof loadService<object, SocialServiceDefinition>>>
   let result: Awaited<ReturnType<typeof createSocialClientV2>>
   let targetAddress: string
 
-  // Mock methods for the service
-  let getFriends: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['getFriends']>
-  let getPendingFriendshipRequests: jest.MockedFunction<
-    ReturnType<typeof loadService<object, SocialServiceDefinition>>['getPendingFriendshipRequests']
-  >
-  let getSentFriendshipRequests: jest.MockedFunction<
-    ReturnType<typeof loadService<object, SocialServiceDefinition>>['getSentFriendshipRequests']
-  >
-  let getFriendshipStatus: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['getFriendshipStatus']>
-  let getMutualFriends: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['getMutualFriends']>
-  let upsertFriendship: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['upsertFriendship']>
-  let subscribeToFriendConnectivityUpdates: jest.MockedFunction<
-    ReturnType<typeof loadService<object, SocialServiceDefinition>>['subscribeToFriendConnectivityUpdates']
-  >
-  let subscribeToFriendshipUpdates: jest.MockedFunction<
-    ReturnType<typeof loadService<object, SocialServiceDefinition>>['subscribeToFriendshipUpdates']
-  >
-  let getSocialSettings: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['getSocialSettings']>
-  let upsertSocialSettings: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['upsertSocialSettings']>
-  let getPrivateMessagesSettings: jest.MockedFunction<
-    ReturnType<typeof loadService<object, SocialServiceDefinition>>['getPrivateMessagesSettings']
-  >
-  let subscribeToBlockUpdates: jest.MockedFunction<
-    ReturnType<typeof loadService<object, SocialServiceDefinition>>['subscribeToBlockUpdates']
-  >
-  let getBlockingStatus: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['getBlockingStatus']>
-  let getBlockedUsers: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['getBlockedUsers']>
-  let blockUser: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['blockUser']>
-  let unblockUser: jest.MockedFunction<ReturnType<typeof loadService<object, SocialServiceDefinition>>['unblockUser']>
-
   beforeEach(async () => {
+    createRpcClientMock = jest.mocked(createRpcClient)
+    createWebSocketsTransportMock = jest.mocked(createWebSocketsTransport)
+    loadServiceMock = jest.mocked(loadService)
+
     socialClientRpcUrl = 'ws:///social-service-v2.decentraland.org'
 
     const wallet = Wallet.createRandom()
@@ -104,51 +87,40 @@ describe('when creating a new client v2', () => {
     } as unknown as Transport & { connect: () => void; sendMessage: jest.Mock; on: jest.Mock; close: jest.Mock }
 
     // Set up port and rpc client mocks
-    port = {} as RpcClientPort
+    portCloseMock = jest.fn()
+    port = { close: portCloseMock } as unknown as RpcClientPort
     rpcClient = { createPort: jest.fn().mockResolvedValue(port) } as RpcClient
-
-    // Mock all service methods
-    getFriends = jest.fn()
-    getPendingFriendshipRequests = jest.fn()
-    getSentFriendshipRequests = jest.fn()
-    getFriendshipStatus = jest.fn()
-    getMutualFriends = jest.fn()
-    upsertFriendship = jest.fn()
-    subscribeToFriendConnectivityUpdates = jest.fn()
-    subscribeToFriendshipUpdates = jest.fn()
-    getSocialSettings = jest.fn()
-    upsertSocialSettings = jest.fn()
-    getPrivateMessagesSettings = jest.fn()
-    subscribeToBlockUpdates = jest.fn()
-    getBlockingStatus = jest.fn()
-    getBlockedUsers = jest.fn()
-    blockUser = jest.fn()
-    unblockUser = jest.fn()
 
     // Set up the loadService result
     loadServiceResult = {
-      getFriends,
-      getPendingFriendshipRequests,
-      getSentFriendshipRequests,
-      getFriendshipStatus,
-      getMutualFriends,
-      upsertFriendship,
-      subscribeToFriendConnectivityUpdates,
-      subscribeToFriendshipUpdates,
-      getSocialSettings,
-      upsertSocialSettings,
-      getPrivateMessagesSettings,
-      subscribeToBlockUpdates,
-      getBlockingStatus,
-      getBlockedUsers,
-      blockUser,
-      unblockUser
-    } as unknown as ReturnType<typeof loadService<object, SocialServiceDefinition>>
+      getFriends: jest.fn(),
+      getPendingFriendshipRequests: jest.fn(),
+      getSentFriendshipRequests: jest.fn(),
+      getFriendshipStatus: jest.fn(),
+      getMutualFriends: jest.fn(),
+      upsertFriendship: jest.fn(),
+      subscribeToFriendConnectivityUpdates: jest.fn(),
+      subscribeToFriendshipUpdates: jest.fn(),
+      getSocialSettings: jest.fn(),
+      upsertSocialSettings: jest.fn(),
+      getPrivateMessagesSettings: jest.fn(),
+      subscribeToBlockUpdates: jest.fn(),
+      getBlockingStatus: jest.fn(),
+      getBlockedUsers: jest.fn(),
+      blockUser: jest.fn(),
+      unblockUser: jest.fn(),
+      startPrivateVoiceChat: jest.fn(),
+      rejectPrivateVoiceChat: jest.fn(),
+      acceptPrivateVoiceChat: jest.fn(),
+      endPrivateVoiceChat: jest.fn(),
+      getIncomingPrivateVoiceChatRequest: jest.fn(),
+      subscribeToPrivateVoiceChatUpdates: jest.fn()
+    }
 
     // Set up mocks
     createWebSocketsTransportMock.mockReturnValueOnce(transport)
     createRpcClientMock.mockResolvedValueOnce(rpcClient)
-    loadServiceMock.mockReturnValueOnce(loadServiceResult)
+    loadServiceMock.mockReturnValueOnce(loadServiceResult as unknown as ReturnType<typeof loadService<object, SocialServiceDefinition>>)
 
     // Simulate the connect event and callback invocation
     transport.on.mockImplementation((event, callback) => {
@@ -189,6 +161,7 @@ describe('when creating a new client v2', () => {
     it('should close the websocket transport', () => {
       result.disconnect()
       expect(transport.close).toHaveBeenCalled()
+      expect(portCloseMock).toHaveBeenCalled()
     })
   })
 
@@ -208,12 +181,12 @@ describe('when creating a new client v2', () => {
           ],
           paginationData: { page: 0, total: 1 }
         }
-        getFriends.mockResolvedValueOnce(response)
+        loadServiceResult.getFriends.mockResolvedValueOnce(response)
       })
 
       it('should return the friends', async () => {
         await expect(result.getFriends()).resolves.toEqual(response)
-        expect(getFriends).toHaveBeenCalledWith(GetFriendsPayload.create({ pagination: undefined }))
+        expect(loadServiceResult.getFriends).toHaveBeenCalledWith(GetFriendsPayload.create({ pagination: undefined }))
       })
     })
   })
@@ -241,12 +214,14 @@ describe('when creating a new client v2', () => {
           },
           paginationData: { page: 0, total: 1 }
         }
-        getPendingFriendshipRequests.mockResolvedValueOnce(response)
+        loadServiceResult.getPendingFriendshipRequests.mockResolvedValueOnce(response)
       })
 
       it('should return the pending requests', async () => {
         await expect(result.getPendingFriendshipRequests()).resolves.toEqual(response)
-        expect(getPendingFriendshipRequests).toHaveBeenCalledWith(GetFriendshipRequestsPayload.create({ pagination: undefined }))
+        expect(loadServiceResult.getPendingFriendshipRequests).toHaveBeenCalledWith(
+          GetFriendshipRequestsPayload.create({ pagination: undefined })
+        )
       })
     })
   })
@@ -259,7 +234,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        getSentFriendshipRequests.mockResolvedValueOnce(response)
+        loadServiceResult.getSentFriendshipRequests.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -293,12 +268,14 @@ describe('when creating a new client v2', () => {
           },
           paginationData: { page: 0, total: 1 }
         }
-        getSentFriendshipRequests.mockResolvedValueOnce(response)
+        loadServiceResult.getSentFriendshipRequests.mockResolvedValueOnce(response)
       })
 
       it('should return the sent requests', async () => {
         await expect(result.getSentFriendshipRequests()).resolves.toEqual(response)
-        expect(getSentFriendshipRequests).toHaveBeenCalledWith(GetFriendshipRequestsPayload.create({ pagination: undefined }))
+        expect(loadServiceResult.getSentFriendshipRequests).toHaveBeenCalledWith(
+          GetFriendshipRequestsPayload.create({ pagination: undefined })
+        )
       })
     })
   })
@@ -311,7 +288,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        getFriendshipStatus.mockResolvedValueOnce(response)
+        loadServiceResult.getFriendshipStatus.mockResolvedValueOnce(response)
       })
 
       it('should reject throwing the received message', () => {
@@ -333,12 +310,12 @@ describe('when creating a new client v2', () => {
             message: 'Friends'
           }
         }
-        getFriendshipStatus.mockResolvedValueOnce(response)
+        loadServiceResult.getFriendshipStatus.mockResolvedValueOnce(response)
       })
 
       it('should return the friendship status', async () => {
         await expect(result.getFriendshipStatus(targetAddress)).resolves.toEqual(response.accepted)
-        expect(getFriendshipStatus).toHaveBeenCalledWith(
+        expect(loadServiceResult.getFriendshipStatus).toHaveBeenCalledWith(
           GetFriendshipStatusPayload.create({ user: User.create({ address: targetAddress }) })
         )
       })
@@ -361,12 +338,14 @@ describe('when creating a new client v2', () => {
           ],
           paginationData: { page: 0, total: 1 }
         }
-        getMutualFriends.mockResolvedValueOnce(response)
+        loadServiceResult.getMutualFriends.mockResolvedValueOnce(response)
       })
 
       it('should return the mutual friends', async () => {
         await expect(result.getMutualFriends(targetAddress)).resolves.toEqual(response)
-        expect(getMutualFriends).toHaveBeenCalledWith(GetMutualFriendsPayload.create({ user: User.create({ address: targetAddress }) }))
+        expect(loadServiceResult.getMutualFriends).toHaveBeenCalledWith(
+          GetMutualFriendsPayload.create({ user: User.create({ address: targetAddress }) })
+        )
       })
     })
   })
@@ -379,7 +358,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -407,12 +386,12 @@ describe('when creating a new client v2', () => {
             }
           }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should return the friendship status', async () => {
         await expect(result.requestFriendship(targetAddress)).resolves.toEqual(response.accepted)
-        expect(upsertFriendship).toHaveBeenCalledWith(
+        expect(loadServiceResult.upsertFriendship).toHaveBeenCalledWith(
           UpsertFriendshipPayload.create({ request: { user: User.create({ address: targetAddress }), message: undefined } })
         )
       })
@@ -427,7 +406,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -455,12 +434,12 @@ describe('when creating a new client v2', () => {
             }
           }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should return the friendship status', async () => {
         await expect(result.acceptFriendshipRequest(targetAddress)).resolves.toEqual(response.accepted)
-        expect(upsertFriendship).toHaveBeenCalledWith(
+        expect(loadServiceResult.upsertFriendship).toHaveBeenCalledWith(
           UpsertFriendshipPayload.create({ accept: { user: User.create({ address: targetAddress }) } })
         )
       })
@@ -475,7 +454,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -504,12 +483,12 @@ describe('when creating a new client v2', () => {
             message: 'A message'
           }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should return the friendship status', async () => {
         await expect(result.rejectFriendshipRequest(targetAddress)).resolves.toEqual(response.accepted)
-        expect(upsertFriendship).toHaveBeenCalledWith(
+        expect(loadServiceResult.upsertFriendship).toHaveBeenCalledWith(
           UpsertFriendshipPayload.create({ reject: { user: User.create({ address: targetAddress }) } })
         )
       })
@@ -524,7 +503,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -553,12 +532,12 @@ describe('when creating a new client v2', () => {
             message: 'A message'
           }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should return the friendship status', async () => {
         await expect(result.cancelFriendshipRequest(targetAddress)).resolves.toEqual(response.accepted)
-        expect(upsertFriendship).toHaveBeenCalledWith(
+        expect(loadServiceResult.upsertFriendship).toHaveBeenCalledWith(
           UpsertFriendshipPayload.create({ cancel: { user: User.create({ address: targetAddress }) } })
         )
       })
@@ -573,7 +552,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -602,12 +581,12 @@ describe('when creating a new client v2', () => {
             message: 'A message'
           }
         }
-        upsertFriendship.mockResolvedValueOnce(response)
+        loadServiceResult.upsertFriendship.mockResolvedValueOnce(response)
       })
 
       it('should return the friendship status', async () => {
         await expect(result.deleteFriendshipRequest(targetAddress)).resolves.toEqual(response.accepted)
-        expect(upsertFriendship).toHaveBeenCalledWith(
+        expect(loadServiceResult.upsertFriendship).toHaveBeenCalledWith(
           UpsertFriendshipPayload.create({ delete: { user: User.create({ address: targetAddress }) } })
         )
       })
@@ -617,7 +596,7 @@ describe('when creating a new client v2', () => {
   describe('when subscribing to friend connectivity updates', () => {
     describe('and the server returns updates', () => {
       beforeEach(() => {
-        subscribeToFriendConnectivityUpdates.mockImplementationOnce(async function* () {
+        loadServiceResult.subscribeToFriendConnectivityUpdates.mockImplementationOnce(async function* () {
           yield {
             friend: {
               address: targetAddress,
@@ -681,7 +660,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        getSocialSettings.mockResolvedValueOnce(response)
+        loadServiceResult.getSocialSettings.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -705,12 +684,12 @@ describe('when creating a new client v2', () => {
             }
           }
         }
-        getSocialSettings.mockResolvedValueOnce(response)
+        loadServiceResult.getSocialSettings.mockResolvedValueOnce(response)
       })
 
       it('should return the social settings', async () => {
-        await expect(result.getSocialSettings()).resolves.toEqual(response)
-        expect(getSocialSettings).toHaveBeenCalledWith(Empty.create())
+        await expect(result.getSocialSettings()).resolves.toEqual(response.ok)
+        expect(loadServiceResult.getSocialSettings).toHaveBeenCalledWith(Empty.create())
       })
     })
   })
@@ -728,7 +707,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        upsertSocialSettings.mockResolvedValueOnce(response)
+        loadServiceResult.upsertSocialSettings.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -750,12 +729,12 @@ describe('when creating a new client v2', () => {
             blockedUsersMessagesVisibility: 1
           }
         }
-        upsertSocialSettings.mockResolvedValueOnce(response)
+        loadServiceResult.upsertSocialSettings.mockResolvedValueOnce(response)
       })
 
       it('should return the updated settings', async () => {
-        await expect(result.upsertSocialSettings(settings)).resolves.toEqual(response)
-        expect(upsertSocialSettings).toHaveBeenCalledWith(UpsertSocialSettingsPayload.create(settings))
+        await expect(result.upsertSocialSettings(settings)).resolves.toEqual(response.ok)
+        expect(loadServiceResult.upsertSocialSettings).toHaveBeenCalledWith(UpsertSocialSettingsPayload.create(settings))
       })
     })
   })
@@ -773,7 +752,7 @@ describe('when creating a new client v2', () => {
         response = {
           internalServerError: { message: 'anErrorOccurred' }
         }
-        getPrivateMessagesSettings.mockResolvedValueOnce(response)
+        loadServiceResult.getPrivateMessagesSettings.mockResolvedValueOnce(response)
       })
 
       it('should reject with the error', () => {
@@ -797,12 +776,12 @@ describe('when creating a new client v2', () => {
             ]
           }
         }
-        getPrivateMessagesSettings.mockResolvedValueOnce(response)
+        loadServiceResult.getPrivateMessagesSettings.mockResolvedValueOnce(response)
       })
 
       it('should return the private messages settings', async () => {
-        await expect(result.getPrivateMessagesSettings(addresses)).resolves.toEqual(response)
-        expect(getPrivateMessagesSettings).toHaveBeenCalledWith(
+        await expect(result.getPrivateMessagesSettings(addresses)).resolves.toEqual(response.ok)
+        expect(loadServiceResult.getPrivateMessagesSettings).toHaveBeenCalledWith(
           GetPrivateMessagesSettingsPayload.create({
             user: addresses.map(address => User.create({ address }))
           })
@@ -820,12 +799,12 @@ describe('when creating a new client v2', () => {
           blockedUsers: [targetAddress],
           blockedByUsers: ['0x2']
         }
-        getBlockingStatus.mockResolvedValueOnce(response)
+        loadServiceResult.getBlockingStatus.mockResolvedValueOnce(response)
       })
 
       it('should return the blocking status', async () => {
         await expect(result.getBlockingStatus()).resolves.toEqual(response)
-        expect(getBlockingStatus).toHaveBeenCalledWith(Empty.create())
+        expect(loadServiceResult.getBlockingStatus).toHaveBeenCalledWith(Empty.create())
       })
     })
   })
@@ -846,12 +825,12 @@ describe('when creating a new client v2', () => {
           ],
           paginationData: { page: 0, total: 1 }
         }
-        getBlockedUsers.mockResolvedValueOnce(response)
+        loadServiceResult.getBlockedUsers.mockResolvedValueOnce(response)
       })
 
       it('should return the blocked users', async () => {
         await expect(result.getBlockedUsers()).resolves.toEqual(response)
-        expect(getBlockedUsers).toHaveBeenCalledWith(GetBlockedUsersPayload.create({ pagination: undefined }))
+        expect(loadServiceResult.getBlockedUsers).toHaveBeenCalledWith(GetBlockedUsersPayload.create({ pagination: undefined }))
       })
     })
   })
@@ -871,12 +850,27 @@ describe('when creating a new client v2', () => {
             }
           }
         }
-        blockUser.mockResolvedValueOnce(response)
+        loadServiceResult.blockUser.mockResolvedValueOnce(response)
       })
 
       it('should return the block result', async () => {
-        await expect(result.blockUser(targetAddress)).resolves.toEqual(response)
-        expect(blockUser).toHaveBeenCalledWith(BlockUserPayload.create({ user: User.create({ address: targetAddress }) }))
+        await expect(result.blockUser(targetAddress)).resolves.toEqual(response.ok)
+        expect(loadServiceResult.blockUser).toHaveBeenCalledWith(BlockUserPayload.create({ user: User.create({ address: targetAddress }) }))
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.blockUser.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.blockUser(targetAddress)).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
       })
     })
   })
@@ -896,12 +890,210 @@ describe('when creating a new client v2', () => {
             }
           }
         }
-        unblockUser.mockResolvedValueOnce(response)
+        loadServiceResult.unblockUser.mockResolvedValueOnce(response)
       })
 
       it('should return the unblock result', async () => {
-        await expect(result.unblockUser(targetAddress)).resolves.toEqual(response)
-        expect(unblockUser).toHaveBeenCalledWith(UnblockUserPayload.create({ user: User.create({ address: targetAddress }) }))
+        await expect(result.unblockUser(targetAddress)).resolves.toEqual(response.ok)
+        expect(loadServiceResult.unblockUser).toHaveBeenCalledWith(
+          UnblockUserPayload.create({ user: User.create({ address: targetAddress }) })
+        )
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.unblockUser.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.unblockUser(targetAddress)).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
+      })
+    })
+  })
+
+  describe('when starting a private voice chat', () => {
+    let response: StartPrivateVoiceChatResponse
+
+    describe('and the server returns successfully', () => {
+      beforeEach(() => {
+        response = {
+          ok: {
+            callId: '123'
+          }
+        }
+        loadServiceResult.startPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should resolve with the voice chat result', async () => {
+        await expect(result.startPrivateVoiceChat(targetAddress)).resolves.toEqual(response.ok)
+        expect(loadServiceResult.startPrivateVoiceChat).toHaveBeenCalledWith(
+          StartPrivateVoiceChatPayload.create({ callee: User.create({ address: targetAddress }) })
+        )
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.startPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.startPrivateVoiceChat(targetAddress)).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
+      })
+    })
+  })
+
+  describe('when rejecting a private voice chat', () => {
+    let response: RejectPrivateVoiceChatResponse
+
+    describe('and the server returns successfully', () => {
+      beforeEach(() => {
+        response = {
+          ok: {
+            callId: '123'
+          }
+        }
+        loadServiceResult.rejectPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should resolve with the voice chat result', async () => {
+        await expect(result.rejectPrivateVoiceChat('123')).resolves.toEqual(response.ok)
+        expect(loadServiceResult.rejectPrivateVoiceChat).toHaveBeenCalledWith(RejectPrivateVoiceChatPayload.create({ callId: '123' }))
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.rejectPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.rejectPrivateVoiceChat('123')).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
+      })
+    })
+  })
+
+  describe('when accepting a private voice chat', () => {
+    let response: AcceptPrivateVoiceChatResponse
+
+    describe('and the server returns successfully', () => {
+      beforeEach(() => {
+        response = {
+          ok: {
+            callId: '123',
+            credentials: {
+              connectionUrl: 'a-connection-url'
+            }
+          }
+        }
+        loadServiceResult.acceptPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should resolve with the voice chat result', async () => {
+        await expect(result.acceptPrivateVoiceChat('123')).resolves.toEqual(response.ok)
+        expect(loadServiceResult.acceptPrivateVoiceChat).toHaveBeenCalledWith(AcceptPrivateVoiceChatPayload.create({ callId: '123' }))
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.acceptPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.acceptPrivateVoiceChat('123')).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
+      })
+    })
+  })
+
+  describe('when ending a private voice chat', () => {
+    let response: EndPrivateVoiceChatResponse
+
+    describe('and the server returns successfully', () => {
+      beforeEach(() => {
+        response = {
+          ok: {
+            callId: '123'
+          }
+        }
+        loadServiceResult.endPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should resolve with the voice chat result', async () => {
+        await expect(result.endPrivateVoiceChat('123')).resolves.toEqual(response.ok)
+        expect(loadServiceResult.endPrivateVoiceChat).toHaveBeenCalledWith(EndPrivateVoiceChatPayload.create({ callId: '123' }))
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.endPrivateVoiceChat.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.endPrivateVoiceChat('123')).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
+      })
+    })
+  })
+
+  describe('when getting incoming private voice chat requests', () => {
+    let response: GetIncomingPrivateVoiceChatRequestResponse
+
+    describe('and the server returns successfully', () => {
+      beforeEach(() => {
+        response = {
+          ok: {
+            callId: '123',
+            caller: User.create({ address: targetAddress })
+          }
+        }
+        loadServiceResult.getIncomingPrivateVoiceChatRequest.mockResolvedValueOnce(response)
+      })
+
+      it('should resolve with the voice chat result', async () => {
+        await expect(result.getIncomingPrivateVoiceChatRequests()).resolves.toEqual(response.ok)
+        expect(loadServiceResult.getIncomingPrivateVoiceChatRequest).toHaveBeenCalledWith(Empty.create())
+      })
+    })
+
+    describe('and the server returns an error', () => {
+      beforeEach(() => {
+        response = {
+          internalServerError: { message: 'anErrorOccurred' }
+        }
+        loadServiceResult.getIncomingPrivateVoiceChatRequest.mockResolvedValueOnce(response)
+      })
+
+      it('should reject with the error', () => {
+        return expect(result.getIncomingPrivateVoiceChatRequests()).rejects.toThrow(
+          new SocialClientInternalServerError(response.internalServerError?.message ?? '')
+        )
       })
     })
   })


### PR DESCRIPTION
This PR does the following:
- (Breaking) Changes some of the client responses which were not correct, as they should return the `Ok` response.
- Improves tests by removing the definition of each variable from the `loadServiceResult` and placing them into an object.
- Updates the protocol and adds the RPC calls for the new methods.
- Makes the `createSocialClient` return a `connect` function to connect the client to the server instead of connecting to it when creating the client.